### PR TITLE
Fix(?) for hitsplats displaying above other interfaces

### DIFF
--- a/src/main/java/com/extendedhitsplats/overlays/ExtendedHitsplatsOverlay.java
+++ b/src/main/java/com/extendedhitsplats/overlays/ExtendedHitsplatsOverlay.java
@@ -53,8 +53,8 @@ public class ExtendedHitsplatsOverlay extends Overlay
     private ExtendedHitsplatsOverlay(ExtendedHitsplatsPlugin plugin, ExtendedHitsplatsConfig config, Client client)
     {
         setPosition(OverlayPosition.DYNAMIC);
-        setPriority(OverlayPriority.HIGHEST);
-        setLayer(OverlayLayer.ALWAYS_ON_TOP);
+        setPriority(OverlayPriority.LOW);
+        setLayer(OverlayLayer.ABOVE_SCENE);
         this.plugin = plugin;
         this.config = config;
         this.client = client;


### PR DESCRIPTION
Hello!
A small fix for hitsplats displaying over the other interfaces.
There's a chance I missed something in testing, so please double check if you can.

Thanks!

PS: might look into that other issue of splats staying on dead enemies too 